### PR TITLE
Typo

### DIFF
--- a/Home.html
+++ b/Home.html
@@ -43,7 +43,7 @@ g0v.tw 在yahoo hackday 做了中央預算視覺化贏得佳作，但這只是�
 <p>有時間出時間，沒時間可以考慮出錢贊助幫忙付Hackthon的場地費，點心費。:)</p>
 <h2>聯絡方式</h2>
 <ul>
-<li>IRC: #g0v.tw on freenode.tw</li>
+<li>IRC: #g0v.tw on freenode</li>
 <li>WebChat: <a href="http://webchat.freenode.net/?channels=g0v.tw">g0v 聊天室</a></li>
 </ul>
 <h2>正在進行中的專案</h2>


### PR DESCRIPTION
首頁的IRC server誤植為freenode.tw，應為freenode
